### PR TITLE
subo correción vistas sin log in

### DIFF
--- a/src/front/js/component/navbar/navbar.js
+++ b/src/front/js/component/navbar/navbar.js
@@ -8,25 +8,27 @@ import { Context } from "../../store/appContext";
 const Navbar = () => {
 	const { store, actions } = useContext(Context);
 
-	const Logout = () => {
-		return <LinkNav name="Cerrar Sesión" to="/" onClick={() => actions.logout()} />;
+	const getFavorites = () => {
+		return "Favoritos(" + store.favs.length + ")";
 	};
 
 	const LoginAndRegister = () => {
-		return (
-			<div className="d-flex justify-content-center align-items-center">
-				<LinkNav name="Ingresar" to="/login"></LinkNav>
-				<LinkNav name="Registrarse" to="/register"></LinkNav>
-			</div>
-		);
-	};
-
-	const LinksAccount = () => {
-		return store.token ? <Logout /> : <LoginAndRegister />;
-	};
-
-	const getFavorites = () => {
-		return "Favoritos(" + store.favs.length + ")";
+		if (store.token) {
+			return (
+				<div>
+					<LinkNav name={getFavorites()} to="/favorites" />
+					<LinkNav name="Garden" to="/garden" />
+					<LinkNav name="Cerrar Sesión" to="/" onClick={() => actions.logout()} />;
+				</div>
+			);
+		} else {
+			return (
+				<div className="d-flex justify-content-center align-items-center">
+					<LinkNav name="Ingresar" to="/login"></LinkNav>
+					<LinkNav name="Registrarse" to="/register"></LinkNav>
+				</div>
+			);
+		}
 	};
 
 	return (
@@ -42,11 +44,8 @@ const Navbar = () => {
 			<div className="collapse navbar-collapse" id="navbarSupportedContent">
 				<ul className="navbar-nav mr-auto">
 					<LinkNav name="Plantas" to="/plants" />
-					<LinkNav name={getFavorites()} to="/favorites" />
-					<LinkNav name="Garden" to="/garden" />
-
 					{/* Botones condicionados */}
-					<LinksAccount />
+					<LoginAndRegister />
 				</ul>
 			</div>
 

--- a/src/front/js/component/plantCard.js
+++ b/src/front/js/component/plantCard.js
@@ -25,8 +25,19 @@ const plantsCard = props => {
 			data4: props.fullScientName,
 			url: props.image
 		});
+	};
 
-		history.push("/favorites");
+	const renderButtons = props => {
+		if (store.token) {
+			<div className="d-flex justify-content-end align-items-center">
+				<button className="btn btn-sm btn-success mr-2" onClick={() => moveData(props.scientName, props.image)}>
+					Sembrar <i className="fas fa-seedling ml-1"></i>
+				</button>
+				<button className="btn btn-sm btn-danger text-white" onClick={() => addFav(props)}>
+					<i className="far fa-heart"></i>
+				</button>
+			</div>;
+		}
 	};
 
 	return (
@@ -35,16 +46,7 @@ const plantsCard = props => {
 			<div className="card-body">
 				<h5 className="card-title text-truncate">{props.name}</h5>
 				<p className="card-text">{props.scientName}</p>
-				<div className="d-flex justify-content-end align-items-center">
-					<button
-						className="btn btn-sm btn-success mr-2"
-						onClick={() => moveData(props.scientName, props.image)}>
-						Sembrar <i className="fas fa-seedling ml-1"></i>
-					</button>
-					<button className="btn btn-sm btn-danger text-white" onClick={() => addFav(props)}>
-						<i className="far fa-heart"></i>
-					</button>
-				</div>
+				<renderButtons />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Modificación en los files de plantCard y Navbar para eliminar el redireccionamiento del botón de favoritos hacia el view de Favoritos y que solo cumpla la función de agregar el elemento a Favoritos.
Retiro de las opciones de Favoritos y Garden del Navbar, cuando no se esté logueado en la página, así como la eliminación de los botones de Sembrar y Favoritos del view de Plantas también para cuando no se esté logueado en la página. 